### PR TITLE
Fix #1 Allow serverId to be specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ The options include:
 * `maxServers` The number of servers to run a download test on. The fastest is used for the upload test and the fastest result is reported at the end.
 * `headers` Headers to send to speedtest.net
 * `log` (Visual only) Pass a truthy value to allow the run to output results to the console in addition to showing progress, or a function to be used instead of `console.log`.
+* `serverId` ID of the server to restrict the tests against.
 
 ## Events
 

--- a/index.js
+++ b/index.js
@@ -246,7 +246,7 @@ function pingServer(server,callback){
   
 function pingServers(servers,count,callback){
   var result=[],todo=Math.min(count,servers.length),done=0;
-  for(var n=0;n<=todo;n++)(function(server){
+  for(var n=0;n<todo;n++)(function(server){
     result.push(server);
     server.bestPing=3600,
     pingServer(server,function(err,bestTime){
@@ -382,7 +382,7 @@ function speedTest(options){
   options=options||{};
 
   options.maxTime=options.maxTime||10000;
-  options.pingCount=options.pingCount||5;
+  options.pingCount=options.pingCount||(options.serverId ? 1 : 5);
   options.maxServers=options.maxServers||1;
   
   var self=new EventEmitter();
@@ -424,6 +424,10 @@ function speedTest(options){
     
     servers=[];
     for (var n=0;n<s.length;n++){
+      if (options.serverId && s[n].$.id == options.serverId) {
+          servers = [s[n].$];
+          break;
+      }
       servers.push(s[n].$);
     }
     


### PR DESCRIPTION
This adds the ability to specify options.serverId to restrict the test to a particular server rather than pinging.