### PR TITLE
Added option to pass servers URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ The options include:
 * `headers` Headers to send to speedtest.net
 * `log` (Visual only) Pass a truthy value to allow the run to output results to the console in addition to showing progress, or a function to be used instead of `console.log`.
 * `serverId` ID of the server to restrict the tests against.
+* `serversUrl` URL to obtain the list of servers available for speed test. (default: http://www.speedtest.net/speedtest-servers-static.php)
 
 ## Events
 

--- a/index.js
+++ b/index.js
@@ -452,7 +452,13 @@ function speedTest(options){
         gotData();
     }
 
-    getXML(httpOpts('http://www.speedtest.net/speedtest-servers-static.php'),gotServers);
+
+    var serversUrl = 'http://www.speedtest.net/speedtest-servers-static.php';
+    if (options.serversUrl) {
+        serversUrl = options.serversUrl;
+    }
+
+    getXML(httpOpts(serversUrl), gotServers);
 
     function gotServers(err,servers){
         if (err) return self.emit('error',err);


### PR DESCRIPTION
Added a new option to allow client to pass in a custom URL to obtain
list of speed test servers. This is useful in the case you are hosting
your own mini speed test instance on a private server. You can run the
speed test against your own domain.