### PR TITLE
Default to Chrome 41.0.2228.0 user-agent for getHttp()

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,7 +92,7 @@ function getHttp(theUrl, discard, callback) {
   delete options.protocol;
 
   options.headers = options.headers || {};
-  options.headers['user-agent'] = options.headers['user-agent'] || 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.8; rv:24.0) Gecko/20100101 Firefox/24.0';
+  options.headers['user-agent'] = options.headers['user-agent'] || 'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36';
 
   http.get(options, function(res) {
     var data = ''


### PR DESCRIPTION
As discussed in #19, this addresses the issue by using a different browser user-agent in `getHttp()` during the request for configuration from speedtest.net. The previous default user-agent has been blocked by the service so the request fails if consumers rely on the default option.

Long-term solution would possibly be to cache the client xml being used from http://www.speedtest.net/speedtest-config.php and clearing this cache when there's a change in IP.