### PR TITLE
HTTP errors lead to bad upload and download speeds.

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,7 +103,6 @@ function getHttp(theUrl, discard, callback) {
       ;
 
     if (!discard) res.setEncoding('utf8');
-    res.on('error', callback);
     res.on('data', function(newData) {
       count += newData.length;
       if (!discard) data += newData;
@@ -144,7 +143,6 @@ function postHttp(theUrl, data, callback) {
   req = http.request(options, function(res) {
     var data = '';
     res.setEncoding('utf8');
-    res.on('error', callback);
     res.on('data', function(newData) {
       data += newData;
     });
@@ -198,13 +196,12 @@ function randomPutHttp(theUrl, size, callback) {
 
   var req = http.request(options, function(res) {
     var data = '';
-    res.on('error', callback);
     res.on('data', function(newData) {
       //discard
     });
     res.on('end', function() {
       //discard data
-      callback(null, size); //return original size
+      callback(null, size, res.statusCode); //return original size
     });
   });
 
@@ -354,7 +351,10 @@ function downloadSpeed(urls, maxTime, callback) {
 
     started++;
 
-    getHttp(url, true, function(err, count) { //discard all data and return byte count
+    getHttp(url, true, function(err, count, status) { //discard all data and return byte count
+      if (err || status !== 200) {
+        count = 0;
+      }
       var diff = process.hrtime(timeStart)
         , timePct
         , amtPct
@@ -429,9 +429,9 @@ function uploadSpeed(url, sizes, maxTime, callback) {
     started++;
     //started=(started+1) % todo; //Keep staing more until the time is up...
 
-    randomPutHttp(url, size, function(err, count) { //discard all data and return byte count
+    randomPutHttp(url, size, function(err, count, status) { //discard all data and return byte count
       if (done >= todo) return;
-      if (err) {
+      if (err || status !== 200) {
         count = 0;
       }
       var diff = process.hrtime(timeStart)


### PR DESCRIPTION
http.IncomingMessage does not emit 'error' events, so HTTP errors are being missed and the byte count is incorrect. This affects both downloads and uploads, but is the most profound for uploads. I first noticed the issue when I got multi-gigabit upload speeds on a home connection. This fix uses HTTP status codes to detect errors and removes any `error` callbacks for the `res` (because `error` will never be raised).