### PR TITLE
Add ability for interface binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ test.on('data', data => {
 test.on('error', err => {
   console.error(err);
 });
-  
+
 ```
 
 Visual use example:
@@ -61,6 +61,7 @@ The options include:
 * `log` (Visual only) Pass a truthy value to allow the run to output results to the console in addition to showing progress, or a function to be used instead of `console.log`.
 * `serverId` ID of the server to restrict the tests against.
 * `serversUrl` URL to obtain the list of servers available for speed test. (default: http://www.speedtest.net/speedtest-servers-static.php)
+* `sourceIp` The source IP to bind for testing with speedtest.net.
 
 ## Proxy by env
 
@@ -88,7 +89,7 @@ test.on('data', data => {
 test.on('error', err => {
   console.error(err);
 });
-  
+
 ```
 
 ### You can set proxy by options
@@ -111,7 +112,7 @@ test.on('data', data => {
 test.on('error', err => {
   console.error(err);
 });
-  
+
 ```
 ### Proxy priority
  * `proxy by options`
@@ -286,8 +287,8 @@ The returned data is a nested object with the following properties:
  * `upload`: upload bandwidth in megabits per second
  * `originalDownload`: unadjusted download bandwidth in bytes per second
  * `originalUpload`: unadjusted upload bandwidth in bytes per second
-  
-  
+
+
 *  __`client`__:
  * `ip`: ip of client
  * `lat`: latitude of client
@@ -297,8 +298,8 @@ The returned data is a nested object with the following properties:
  * `rating`: another rating, which is always 0 it seems
  * `ispdlavg`: avg download speed by all users of this isp in Mbps
  * `ispulavg`: same for upload
-  
-  
+
+
 * __`server`__:
  * `host`: test server url
  * `lat`: latitude of server

--- a/bin/index.js
+++ b/bin/index.js
@@ -62,7 +62,7 @@ function renderStatus(statuses, step, spinner){
    // Build Status
   for (var k in statuses) {
     var status = statuses[k];
-    
+
     // Account for status where it's false/true
     // (indicating not started and not received value yet)
     status = status === false ? '' : status;
@@ -124,7 +124,7 @@ function speedText(speed) {
 
   // Make it fixed
   var str = speed.toFixed(places);
-  
+
   // Concat with unit
   return str + ' Mbps';
 }
@@ -170,11 +170,12 @@ updateLines();
 /*
  * Start speed test
  */
- 
+
 var options = {
   maxTime: 10000,
-  proxy : null,
-}
+  proxy: null,
+  sourceIp: null,
+};
 
 /*
  * get parameters
@@ -182,11 +183,17 @@ var options = {
 var errorParameter = null;
 process.argv.forEach(function (val, index, array) {
   if (index >= 2) {
-    if (val.startsWith("--proxy")) {
-      if (array[index + 1] != undefined) {
+    if (val === '--proxy') {
+      if (array[index + 1] !== undefined) {
         options.proxy = array[index + 1];
       } else {
-        errorParameter = "Error: bad parameters";
+        errorParameter = 'Error: bad parameters';
+      }
+    } else if (val === '--sourceip') {
+      if (array[index + 1] !== undefined) {
+        options.sourceIp = array[index + 1];
+      } else {
+        errorParameter = 'Error: bad parameters';
       }
     }
   }
@@ -225,7 +232,7 @@ test.once('testserver', function (info){
   title = centerText(title, width * 3);
 
   locate('│' + chalk.yellow(title) + '│');
-  
+
   var ping = Math.round(info.bestPing * 10) / 10;
   statuses.Ping = ping + ' ms';
   step = 'Download';


### PR DESCRIPTION
Can now use `--sourceip IP-ADDRESS` arg with the bin file
Or use the `options` object with the key `sourceIp`

It works with IP addresses only.

Closes #61.