### PR TITLE
Add timeout option to http.get

### DIFF
--- a/index.js
+++ b/index.js
@@ -156,6 +156,8 @@ function getHttp(theUrl, discard, callback) {
   options.headers = options.headers || {};
   options.headers['user-agent'] = options.headers['user-agent'] || 'Mozilla/5.0 (Windows NT 6.3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.' + Math.trunc(Math.random() * 400 + 2704) + '.' + Math.trunc(Math.random() * 400 + 103) + ' Safari/537.36';
 
+  options.timeout = 500;
+
   http.get(options, function(res) {
     if (res.statusCode === 302) {
       return getHttp(res.headers.location, discard, callback);


### PR DESCRIPTION
*  Added a 500ms timeout option to http.get function within local getHttp function.
*  Fixes #68: weird bug in Ubuntu 14.04 where callback would not be called unless this option was set.