### PR TITLE
Solved npm high vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "draftlog": "^1.0.12",
     "xml2js": "^0.4.4",
     "http-proxy-agent": "^2.0.0",
-    "https-proxy-agent": "^2.1.1"
+    "https-proxy-agent": "^3.0.0"
   },
   "devDependencies": {
     "eslint": "^4.14.0"


### PR DESCRIPTION
npm audit fix is showing a high severity vulnerability. It was fixed by upgrading `https-proxy-version` to `3.0.0`.