### PR TITLE
Fix #117: license info throwing error and breaking Promise

### DIFF
--- a/index.js
+++ b/index.js
@@ -275,11 +275,15 @@ async function exec(options = {}) {
     kill(pid);
   }
   if (errorLines.length) {
-    let error = errorLines.join('\n');
-    error = error.replace(/===*.*====*\\nLicense acceptance recorded. Continuing.\n?/, '');
+    const licenseAcceptedMessage = /License acceptance recorded. Continuing./;
     const acceptLicenseMessage = /To accept the message please run speedtest interactively or use the following:[\s\S]*speedtest --accept-license/;
     const acceptGdprMessage = /To accept the message please run speedtest interactively or use the following:[\s\S]*speedtest --accept-gdpr/;
-    if (acceptLicenseMessage.test(error)) {
+
+    let error = errorLines.join('\n');
+
+    if (licenseAcceptedMessage.test(error)) {
+      error = '';
+    } else if (acceptLicenseMessage.test(error)) {
       error = error.replace(acceptLicenseMessage, 'To accept the message, pass the acceptLicense: true option');
     } else if (acceptGdprMessage.test(error)) {
       error = error.replace(acceptGdprMessage, 'To accept the message, pass the acceptGdpr: true option');

--- a/index.js
+++ b/index.js
@@ -276,7 +276,7 @@ async function exec(options = {}) {
   }
   if (errorLines.length) {
     let error = errorLines.join('\n');
-    error = error.replace(/===*.*====*\nLicense acceptance recorded. Continuing.\n?/, '');
+    error = error.replace(/===*.*====*\\nLicense acceptance recorded. Continuing.\n?/, '');
     const acceptLicenseMessage = /To accept the message please run speedtest interactively or use the following:[\s\S]*speedtest --accept-license/;
     const acceptGdprMessage = /To accept the message please run speedtest interactively or use the following:[\s\S]*speedtest --accept-gdpr/;
     if (acceptLicenseMessage.test(error)) {


### PR DESCRIPTION
This fixes #117 

The regex check on line 279 never stuck, due to it testing for `\n`, instead of the escaped string version.

**Changes:**
- fixed the regex check
- aligned the test with the other conditions for consistency

**Reproduce:**
use vscode `ms-vscode-remote.remote-containers` extension, to run it in a fresh container -> this will require accepting the license, and throw the error.

I've added a temporary `run.js` locally, where I execute the package and attach to it via node debugger in vscode. (breakpoint line 277). Then its fairly clear that the regex that supposedly should clear the error, does not work.

