### PR TITLE
Update URL of binary location to latest

### DIFF
--- a/index.js
+++ b/index.js
@@ -132,7 +132,7 @@ function appendFileName(fileName, trailer) {
 }
 
 async function ensureBinary({ platform = process.platform, arch = process.arch, binaryVersion = defaultBinaryVersion } = {}) {
-  const binaryLocation = 'https://bintray.com/ookla/download/download_file?file_path=ookla-speedtest-$v-$p';
+  const binaryLocation = 'https://install.speedtest.net/app/cli/ookla-speedtest-$v-$p';
   const found = platforms.find(p => p.platform === platform && p.arch === arch);
   if (!found) throw new Error(`${platform} on ${arch} not supported`);
   const binDir = path.join(__dirname, 'binaries');


### PR DESCRIPTION
The distribution service that was being used to download the binary (Bintray) had a brown-out session on April 12th to notify users about the sunset date for the service.
https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/
https://status.bintray.com/

Ookla was made aware of the downtime, and updated their CLI page with new download URL's. 
https://www.speedtest.net/apps/cli

This PR simply reflects the change in the URL for the binary.